### PR TITLE
pss: ensure space in queue for failed forwards

### DIFF
--- a/pss/pss.go
+++ b/pss/pss.go
@@ -580,10 +580,10 @@ func (p *Pss) enqueue(msg *PssMsg, pending bool) error {
 	}
 	metrics.GetOrRegisterCounter("pss.enqueue.outbox.full", nil).Inc(1)
 	if pending {
-		return errors.New("unexpected outbox full for pending message!")
-	} else {
-		return errors.New("outbox full")
+		log.Crit("unexpected outbox full for pending message!")
+		panic(errors.New("unexpected outbox full for pending message!"))
 	}
+	return errors.New("outbox full")
 }
 
 // Access to forwardPending is protected with RWMutex

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -581,7 +581,6 @@ func (p *Pss) enqueue(msg *PssMsg, pending bool) error {
 	metrics.GetOrRegisterCounter("pss.enqueue.outbox.full", nil).Inc(1)
 	if pending {
 		log.Crit("unexpected outbox full for pending message!")
-		panic(errors.New("unexpected outbox full for pending message!"))
 	}
 	return errors.New("outbox full")
 }

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -565,7 +565,7 @@ func (p *Pss) enqueue(msg *PssMsg, pending bool) error {
 	p.outboxMutex.Lock()
 	defer p.outboxMutex.Unlock()
 	pendingSize := p.getPending()
-	// Only allow defaultOutboxCapacity messages at most processed (both enqueued or being forwarded)
+	// Only allow capacity of outbox messages at most processed (both enqueued or being forwarded)
 	if pending || pendingSize < cap(p.outbox) { //If pending there is already a slot booked for this message
 		if !pending {
 			// We book a slot in the queue increasing pending messages and release it after successfully sending the message


### PR DESCRIPTION
A new flag is added to the enqueue function that allows to distinguish between a new enqueue and a failed forward re-enqueue.
Also before enqueuing a new message, the number of pending forwards is taking into account to check the capacity of the queue 