### PR TITLE
pss: started refactor proposal. Extracted cache functionality to forw…

### DIFF
--- a/pss/forward_cache.go
+++ b/pss/forward_cache.go
@@ -1,0 +1,114 @@
+package pss
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethersphere/swarm/log"
+	"golang.org/x/crypto/sha3"
+	"hash"
+	"sync"
+	"time"
+)
+
+const (
+	hasherCount  = 8
+	digestLength = 32 // byte length of digest used for pss forward cache (currently same as swarm chunk hash)
+)
+
+// ForwadrCache is used for preventing backwards routing
+// will also be instrumental in flood guard mechanism
+// and mailbox implementation
+type ForwardCache struct {
+	fwdCache   map[digest]cacheEntry // checksum of unique fields from pssmsg mapped to expiry, cache to determine whether to drop msg
+	fwdCacheMu sync.RWMutex
+	cacheTTL   time.Duration // how long to keep messages in fwdCache (not implemented)
+	hashPool   sync.Pool
+}
+
+type cacheEntry struct {
+	expiresAt time.Time
+}
+
+type digest [digestLength]byte
+
+func newForwardCache(cacheTTL time.Duration) *ForwardCache {
+	fc := &ForwardCache{
+		fwdCache: make(map[digest]cacheEntry),
+		cacheTTL: cacheTTL,
+		hashPool: sync.Pool{
+			New: func() interface{} {
+				return sha3.NewLegacyKeccak256()
+			},
+		},
+	}
+	for i := 0; i < hasherCount; i++ {
+		hashfunc := sha3.NewLegacyKeccak256()
+		fc.hashPool.Put(hashfunc)
+	}
+	return fc
+}
+
+// add a message to the cache
+func (fc *ForwardCache) addFwdCache(msg *PssMsg) error {
+	defer metrics.GetOrRegisterResettingTimer("pss.addfwdcache", nil).UpdateSince(time.Now())
+
+	var entry cacheEntry
+	var ok bool
+
+	fc.fwdCacheMu.Lock()
+	defer fc.fwdCacheMu.Unlock()
+
+	digest := fc.msgDigest(msg)
+	if entry, ok = fc.fwdCache[digest]; !ok {
+		entry = cacheEntry{}
+	}
+	entry.expiresAt = time.Now().Add(fc.cacheTTL)
+	fc.fwdCache[digest] = entry
+	return nil
+}
+
+// check if message is in the cache
+func (fc *ForwardCache) checkFwdCache(msg *PssMsg) bool {
+	fc.fwdCacheMu.Lock()
+	defer fc.fwdCacheMu.Unlock()
+
+	digest := fc.msgDigest(msg)
+	entry, ok := fc.fwdCache[digest]
+	if ok {
+		if entry.expiresAt.After(time.Now()) {
+			log.Trace("unexpired cache", "digest", fmt.Sprintf("%x", digest))
+			metrics.GetOrRegisterCounter("pss.checkfwdcache.unexpired", nil).Inc(1)
+			return true
+		}
+		metrics.GetOrRegisterCounter("pss.checkfwdcache.expired", nil).Inc(1)
+	}
+	return false
+}
+
+// cleanFwdCache is used to periodically remove expired entries from the forward cache
+func (fc *ForwardCache) cleanFwdCache() {
+	metrics.GetOrRegisterCounter("pss.cleanfwdcache", nil).Inc(1)
+	fc.fwdCacheMu.Lock()
+	defer fc.fwdCacheMu.Unlock()
+	for k, v := range fc.fwdCache {
+		if v.expiresAt.Before(time.Now()) {
+			delete(fc.fwdCache, k)
+		}
+	}
+}
+
+// Digest of message
+func (fc *ForwardCache) msgDigest(msg *PssMsg) digest {
+	return fc.digestBytes(msg.serialize())
+}
+
+func (fc *ForwardCache) digestBytes(msg []byte) digest {
+	hasher := fc.hashPool.Get().(hash.Hash)
+	defer fc.hashPool.Put(hasher)
+	hasher.Reset()
+	hasher.Write(msg)
+	d := digest{}
+	key := hasher.Sum(nil)
+	copy(d[:], key[:digestLength])
+	return d
+}

--- a/pss/outbox.go
+++ b/pss/outbox.go
@@ -1,0 +1,105 @@
+package pss
+
+import (
+	"errors"
+	"time"
+
+	"github.com/ethereum/go-ethereum/metrics"
+
+	"github.com/ethersphere/swarm/log"
+)
+
+type outbox struct {
+	queue   []*outboxMsg
+	slots   chan int
+	process chan int
+	quitC   chan struct{}
+	forward func(msg *PssMsg) error
+}
+
+func newOutbox(capacity int, quitC chan struct{}, forward func(msg *PssMsg) error) outbox {
+	outbox := outbox{
+		queue:   make([]*outboxMsg, capacity),
+		slots:   make(chan int, capacity),
+		process: make(chan int),
+		quitC:   quitC,
+		forward: forward,
+	}
+	// fill up outbox slots
+	for i := 0; i < cap(outbox.slots); i++ {
+		outbox.slots <- i
+	}
+	return outbox
+}
+
+// enqueue a new element in the outbox if there is any slot available.
+// Then send it to process. This method is blocking in the process channel!
+func (o *outbox) enqueue(outboxmsg *outboxMsg) error {
+	// first we try to obtain a slot in the outbox
+	select {
+	case slot := <-o.slots:
+		o.queue[slot] = outboxmsg
+		metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.len()))
+		// we send this message slot to process
+		select {
+		case o.process <- slot:
+		case <-o.quitC:
+		}
+		return nil
+	default:
+		metrics.GetOrRegisterCounter("pss.enqueue.outbox.full", nil).Inc(1)
+		return errors.New("outbox full")
+	}
+}
+
+func (o *outbox) processOutbox() {
+	for slot := range o.process {
+		go func(slot int) {
+			msg := o.msg(slot)
+			metrics.GetOrRegisterResettingTimer("pss.handle.outbox", nil).UpdateSince(msg.startedAt)
+			if err := o.forward(msg.msg); err != nil {
+				metrics.GetOrRegisterCounter("pss.forward.err", nil).Inc(1)
+				// if we failed to forward, re-insert message in the queue
+				log.Debug(err.Error())
+				// reenqueue the message for processing
+				o.reenqueue(slot)
+				log.Debug("Message re-enqued", "slot", slot)
+				return
+			}
+			// free the outbox slot
+			o.free(slot)
+			metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.len()))
+		}(slot)
+	}
+}
+
+func (o outbox) msg(slot int) *outboxMsg {
+	return o.queue[slot]
+}
+
+func (o outbox) free(slot int) {
+	o.slots <- slot
+}
+
+func (o outbox) reenqueue(slot int) {
+	select {
+	case o.process <- slot:
+	case <-o.quitC:
+	}
+
+}
+func (o outbox) len() int {
+	return cap(o.slots) - len(o.slots)
+}
+
+type outboxMsg struct {
+	msg       *PssMsg
+	startedAt time.Time
+}
+
+func newOutboxMsg(msg *PssMsg) *outboxMsg {
+	return &outboxMsg{
+		msg:       msg,
+		startedAt: time.Now(),
+	}
+}

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/p2p/protocols"
@@ -101,90 +102,6 @@ func NewParams() *Params {
 func (params *Params) WithPrivateKey(privatekey *ecdsa.PrivateKey) *Params {
 	params.privateKey = privatekey
 	return params
-}
-
-type outbox struct {
-	queue   []*outboxMsg
-	slots   chan int
-	process chan int
-	quitC   chan struct{}
-	forward func(msg *PssMsg) error
-}
-
-func newOutbox(capacity int, quitC chan struct{}, forward func(msg *PssMsg) error) outbox {
-	outbox := outbox{
-		queue:   make([]*outboxMsg, capacity),
-		slots:   make(chan int, capacity),
-		process: make(chan int),
-		quitC:   quitC,
-		forward: forward,
-	}
-	// fill up outbox slots
-	for i := 0; i < cap(outbox.slots); i++ {
-		outbox.slots <- i
-	}
-	return outbox
-}
-
-func (o outbox) len() int {
-	return cap(o.slots) - len(o.slots)
-}
-
-// enqueue a new element in the outbox if there is any slot available.
-// Then send it to process. This method is blocking in the process channel!
-func (o *outbox) enqueue(outboxmsg *outboxMsg) error {
-	// first we try to obtain a slot in the outbox
-	select {
-	case slot := <-o.slots:
-		o.queue[slot] = outboxmsg
-		metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.len()))
-		// we send this message slot to process
-		select {
-		case o.process <- slot:
-		case <-o.quitC:
-		}
-		return nil
-	default:
-		metrics.GetOrRegisterCounter("pss.enqueue.outbox.full", nil).Inc(1)
-		return errors.New("outbox full")
-	}
-}
-
-func (o *outbox) processOutbox() {
-	for slot := range o.process {
-		go func(slot int) {
-			msg := o.msg(slot)
-			metrics.GetOrRegisterResettingTimer("pss.handle.outbox", nil).UpdateSince(msg.startedAt)
-			if err := o.forward(msg.msg); err != nil {
-				metrics.GetOrRegisterCounter("pss.forward.err", nil).Inc(1)
-				// if we failed to forward, re-insert message in the queue
-				log.Debug(err.Error())
-				// reenqueue the message for processing
-				o.reenqueue(slot)
-				log.Debug("Message re-enqued", "slot", slot)
-				return
-			}
-			// free the outbox slot
-			o.free(slot)
-			metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.len()))
-		}(slot)
-	}
-}
-
-func (o outbox) msg(slot int) *outboxMsg {
-	return o.queue[slot]
-}
-
-func (o outbox) free(slot int) {
-	o.slots <- slot
-}
-
-func (o outbox) reenqueue(slot int) {
-	select {
-	case o.process <- slot:
-	case <-o.quitC:
-	}
-
 }
 
 // Pss is the top-level struct, which takes care of message sending, receiving, decryption and encryption, message handler dispatchers

--- a/pss/types.go
+++ b/pss/types.go
@@ -20,12 +20,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
+
 	"github.com/ethersphere/swarm/storage"
 )
 
@@ -115,18 +115,6 @@ func (m *msgParams) Bytes() (paramBytes []byte) {
 	}
 	paramBytes = append(paramBytes, b)
 	return paramBytes
-}
-
-type outboxMsg struct {
-	msg       *PssMsg
-	startedAt time.Time
-}
-
-func newOutboxMsg(msg *PssMsg) *outboxMsg {
-	return &outboxMsg{
-		msg:       msg,
-		startedAt: time.Now(),
-	}
 }
 
 // PssMsg encapsulates messages transported over pss.

--- a/pss/types.go
+++ b/pss/types.go
@@ -88,7 +88,6 @@ func (a *PssAddress) UnmarshalJSON(input []byte) error {
 }
 
 // holds the digest of a message used for caching
-type digest [digestLength]byte
 
 // conceals bitwise operations on the control flags byte
 type msgParams struct {


### PR DESCRIPTION
I've started the refactor by extracting the forwardCache funcionality into a separate file, forward_cache.go which has its own type ForwardCache that encapsulates all that's needed for the forward cache (hashpool, mutex, ...). Pss has forwardCache as a field of the struct now